### PR TITLE
Add Runelite importer

### DIFF
--- a/src/components/ManageDataModal.js
+++ b/src/components/ManageDataModal.js
@@ -11,6 +11,8 @@ export default function ManageDataModal({ show, onClose }) {
     const [updated, setUpdated] = useState(false);
     const [runeliteImportJson, setRuneliteImportJson] = useState({});
 
+    const pluginHubLink = "https://github.com/runelite/runelite/wiki/Information-about-the-Plugin-Hub";
+
     const loadFile = async (FileObject) => {
         const response = await loadLocalStorageFromFile(FileObject);
         if (response.success) {
@@ -94,6 +96,10 @@ export default function ManageDataModal({ show, onClose }) {
                     </Tab>
                     <Tab eventKey="runelite" title="Runelite Import">
                         <div className="text-center mt-3">
+                            <Alert variant="info" className="small">
+                                The OsLeague plugin from the Runelite Plugin Hub is required.<br/>
+                                <a href={pluginHubLink}>Click here</a> for more information.
+                            </Alert>
                             <Alert variant="warning" className="small">
                                 <b>Note:</b> Importing from Runelite will only update tasks, relics, and areas.
                             </Alert>

--- a/src/components/ManageDataModal.js
+++ b/src/components/ManageDataModal.js
@@ -1,13 +1,15 @@
 import React, { useState } from "react";
-import { Button, Modal, Alert, Tabs, Tab } from "react-bootstrap";
+import { Button, Modal, Alert, Tabs, Tab, InputGroup, FormControl } from "react-bootstrap";
 import { FilePicker } from "react-file-picker";
 import { saveLocalStorageToFile, loadLocalStorageFromFile } from "../util/file-util";
+import { updateLocalStorageFromRuneliteJson } from "../util/runelite-util";
 import { resetLocalStorageData } from "../util/browser-util";
 
 export default function ManageDataModal({ show, onClose }) {
     const [errorText, setErrorText] = useState("");
     const [successText, setSuccessText] = useState("");
     const [updated, setUpdated] = useState(false);
+    const [runeliteImportJson, setRuneliteImportJson] = useState({});
 
     const loadFile = async (FileObject) => {
         const response = await loadLocalStorageFromFile(FileObject);
@@ -26,6 +28,20 @@ export default function ManageDataModal({ show, onClose }) {
     const resetData = () => {
         resetLocalStorageData();
         setUpdated(true);
+    }
+
+    const loadRuneliteImport = async () => {
+        const response = await updateLocalStorageFromRuneliteJson(runeliteImportJson);
+        if (response.success) {
+            setSuccessText(
+                "Successfully imported character data from Runelite."
+            );
+            setErrorText("");
+            setUpdated(true);
+        } else {
+            setSuccessText("");
+            setErrorText(response.message);
+        }
     }
 
     return (
@@ -70,6 +86,29 @@ export default function ManageDataModal({ show, onClose }) {
                                     Import from file
                                 </Button>
                             </FilePicker>
+                            {errorText && <p className="text-danger small">{errorText}</p>}
+                            {successText && (
+                                <p className="text-success small">{successText}</p>
+                            )}
+                        </div>
+                    </Tab>
+                    <Tab eventKey="runelite" title="Runelite Import">
+                        <div className="text-center mt-3">
+                            <Alert variant="warning" className="small">
+                                <b>Note:</b> Importing from Runelite will only update tasks, relics, and areas.
+                            </Alert>
+                            <InputGroup>
+                                <InputGroup.Prepend>
+                                    <InputGroup.Text>Paste copied data from Runelite:</InputGroup.Text>
+                                </InputGroup.Prepend>
+                                <FormControl
+                                    as="textarea"
+                                    onChange={(event) => setRuneliteImportJson(event.target.value)}
+                                    />
+                            </InputGroup>
+                            <Button onClick={loadRuneliteImport} variant="dark" className="m-2">
+                                Import
+                            </Button>
                             {errorText && <p className="text-danger small">{errorText}</p>}
                             {successText && (
                                 <p className="text-success small">{successText}</p>

--- a/src/components/ManageDataModal.js
+++ b/src/components/ManageDataModal.js
@@ -98,8 +98,8 @@ export default function ManageDataModal({ show, onClose }) {
                     <Tab eventKey="runelite" title="Runelite Import">
                         <div className="text-center mt-3">
                             <Alert variant="info" className="small">
-                                The OsLeague plugin from the Runelite Plugin Hub is required.<br/>
-                                <a href={pluginHubLink}>Click here</a> for more information.
+                                <p>The OsLeague plugin from the Runelite Plugin Hub is required.</p>
+                                <p class="mb-0"><a href={pluginHubLink}>Click here</a> for more information.</p>
                             </Alert>
                             <Alert variant="warning" className="small">
                                 <b>Note:</b> Importing from Runelite will only update tasks, relics, and areas.

--- a/src/util/runelite-util.js
+++ b/src/util/runelite-util.js
@@ -1,0 +1,30 @@
+import { getFromLocalStorage, updateLocalStorage } from "./browser-util";
+
+export async function updateLocalStorageFromRuneliteJson(json) {
+    try {
+        const runeliteImport = JSON.parse(json);
+        for (let [key, value] of Object.entries(runeliteImport)) {
+            if (key === "tasks") {
+                const tasksImport = JSON.parse(value);
+                let tasks = getFromLocalStorage("tasks", {version:0, tasks:[], hidden:[], todoList:[]});
+                tasks.tasks = tasksImport.tasks;
+                tasks.version = tasksImport.version;
+                updateLocalStorage("tasks", tasks);
+
+            } else {
+                updateLocalStorage(key, JSON.parse(value));
+            }
+        }
+        return {
+            success: true,
+            message: runeliteImport
+        };
+    }
+    catch (e) {
+        return {
+            success: false,
+            message: "Error parsing the import data: " + e
+        };
+    }
+    
+}


### PR DESCRIPTION
### Changes

1. Added tab to the Manage Data area to import data from Runelite plugin
2. Importing data will only update tasks.tasks, relics, and areas.

![osleague](https://user-images.githubusercontent.com/17709869/98069290-0535cd00-1e24-11eb-90a1-49a8a04b7072.gif)

### Notes
This feature is dependent on the Runelite plugin also developed by me.
PR here: https://github.com/runelite/plugin-hub/pull/741
