### PR TITLE
Added Double Cast Relic support for Magic Calculator and Botanist for Farming

### DIFF
--- a/src/pages/SkillCalculator.js
+++ b/src/pages/SkillCalculator.js
@@ -54,7 +54,7 @@ export default function SkillCalculator() {
     }
     const isMagic = skillData.name === "Magic" ? true : false;
 
-    const { levelFormatter, iconFormatter, amountFormatter, outputListFormatter, inputListFormatter, expFormatter } = getFormatters(hasDoubleCast);
+    const { levelFormatter, iconFormatter, amountFormatter, outputListFormatter, inputListFormatter, expFormatter } = getFormatters();
     const columns = [
         {
             "dataField": "id",
@@ -326,7 +326,7 @@ export default function SkillCalculator() {
                     <BootstrapTable
                         bootstrap4
                         keyField='id'
-                        data={applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, hasDoubleCast, useAreaFilter, includedAreas)}
+                        data={applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas)}
                         columns={columns}
                         bordered={false}
                         classes="light-text"
@@ -339,7 +339,7 @@ export default function SkillCalculator() {
     );
 }
 
-function applyFilters(actions, currentLevel, useLevelFilter, isSkillingProdigy, hasDoubleCast, useAreaFilter, includedAreas) {
+function applyFilters(actions, currentLevel, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas) {
     let filteredActions = actions;
     if (useLevelFilter) {
         const boostedLevel = getBoostedLevel(currentLevel, isSkillingProdigy);

--- a/src/pages/SkillCalculator.js
+++ b/src/pages/SkillCalculator.js
@@ -23,6 +23,7 @@ export default function SkillCalculator() {
     const outputMultiplier = useMultiplier();
     const [useLevelFilter, setUseLevelFilter] = useState(false);
     const [isSkillingProdigy, setIsSkillingProdigy] = useState(isRelicUnlocked('1,3'));
+    const [hasDoubleCast, setHasDoubleCast] = useState(isRelicUnlocked('3,3'));
     const [useAreaFilter, setUseAreaFilter] = useState(true);
     const [includedAreas, setIncludedAreas] = useState(getFromLocalStorage(LOCALSTORAGE_KEYS.UNLOCKED_REGIONS, INITIAL_REGIONS_STATE));
     const { skill } = useParams();
@@ -51,8 +52,9 @@ export default function SkillCalculator() {
             </h4>
         );
     }
+    const isMagic = skillData.name === "Magic" ? true : false;
 
-    const { levelFormatter, iconFormatter, amountFormatter, inputListFormatter, outputListFormatter, expFormatter } = getFormatters();
+    const { levelFormatter, iconFormatter, amountFormatter, outputListFormatter, inputListFormatter, expFormatter } = getFormatters(hasDoubleCast);
     const columns = [
         {
             "dataField": "id",
@@ -111,7 +113,7 @@ export default function SkillCalculator() {
         },
         {
             "dataField": "inputs",
-            "text": "Inputs",
+            "text": isMagic ? hasDoubleCast ? "Minimum Inputs" : "Inputs" : "Inputs",
             "formatter": inputListFormatter,
             "formatExtraData": {
                 "current": currentLevel.exp,
@@ -119,7 +121,8 @@ export default function SkillCalculator() {
                 "baseMultiplier": baseExpMultiplier,
                 "expMultiplier": expMultiplier,
                 "totalLevel": totalLevel,
-                "countMultiplier": inputMultiplier
+                "countMultiplier": inputMultiplier,
+                "hasDoubleCast": isMagic ? hasDoubleCast : false,
             }
         },
         {
@@ -211,6 +214,20 @@ export default function SkillCalculator() {
                                         defaultChecked={isSkillingProdigy}
                                         onChange={(event) => {
                                             setIsSkillingProdigy(event.target.checked);
+                                        }}
+                                    />
+                                </div>
+                            </React.Fragment>
+                        )}
+                        {isMagic && (
+                            <React.Fragment>
+                                <h4>Input Modifiers:</h4>
+                                <div className="pl-2">
+                                    <Form.Check
+                                        label="Relic - Double Cast"
+                                        defaultChecked={hasDoubleCast}
+                                        onChange={(event) => {
+                                            setHasDoubleCast(event.target.checked);
                                         }}
                                     />
                                 </div>
@@ -309,7 +326,7 @@ export default function SkillCalculator() {
                     <BootstrapTable
                         bootstrap4
                         keyField='id'
-                        data={applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas)}
+                        data={applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, hasDoubleCast, useAreaFilter, includedAreas)}
                         columns={columns}
                         bordered={false}
                         classes="light-text"
@@ -322,7 +339,7 @@ export default function SkillCalculator() {
     );
 }
 
-function applyFilters(actions, currentLevel, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas) {
+function applyFilters(actions, currentLevel, useLevelFilter, isSkillingProdigy, hasDoubleCast, useAreaFilter, includedAreas) {
     let filteredActions = actions;
     if (useLevelFilter) {
         const boostedLevel = getBoostedLevel(currentLevel, isSkillingProdigy);

--- a/src/pages/SkillCalculator.js
+++ b/src/pages/SkillCalculator.js
@@ -24,6 +24,7 @@ export default function SkillCalculator() {
     const [useLevelFilter, setUseLevelFilter] = useState(false);
     const [isSkillingProdigy, setIsSkillingProdigy] = useState(isRelicUnlocked('1,3'));
     const [hasDoubleCast, setHasDoubleCast] = useState(isRelicUnlocked('3,3'));
+    const [hasBotanist, setHasBotanist] = useState(isRelicUnlocked('5,1'));
     const [useAreaFilter, setUseAreaFilter] = useState(true);
     const [includedAreas, setIncludedAreas] = useState(getFromLocalStorage(LOCALSTORAGE_KEYS.UNLOCKED_REGIONS, INITIAL_REGIONS_STATE));
     const { skill } = useParams();
@@ -53,6 +54,7 @@ export default function SkillCalculator() {
         );
     }
     const isMagic = skillData.name === "Magic" ? true : false;
+    const isFarming = skillData.name === "Farming" ? true : false;
 
     const { levelFormatter, iconFormatter, amountFormatter, outputListFormatter, inputListFormatter, expFormatter } = getFormatters();
     const columns = [
@@ -67,7 +69,10 @@ export default function SkillCalculator() {
             "sort": true,
             "headerStyle": { width: '10%' },
             "formatter": levelFormatter,
-            "formatExtraData": { "level": currentLevel.level, "isSkillingProdigy": isSkillingProdigy }
+            "formatExtraData": { 
+                "level": currentLevel.level, 
+                "isSkillingProdigy": isSkillingProdigy 
+            }
         },
         {
             "dataField": "name",
@@ -135,7 +140,8 @@ export default function SkillCalculator() {
                 "baseMultiplier": baseExpMultiplier,
                 "expMultiplier": expMultiplier,
                 "totalLevel": totalLevel,
-                "countMultiplier": outputMultiplier
+                "countMultiplier": outputMultiplier,
+                "hasBotanist": isFarming ? hasBotanist : false,
             }
         }
     ];
@@ -200,6 +206,20 @@ export default function SkillCalculator() {
                             multiplierData={skillData.inputMultipliers}
                             multipliers={inputMultiplier}
                         />
+                        {isFarming && (
+                            <React.Fragment>
+                            <h4>Output multiplier:</h4>
+                            <div className="pl-2">
+                                <Form.Check
+                                    label="Relic - Botanist"
+                                    defaultChecked={hasBotanist}
+                                    onChange={(event) => {
+                                        setHasBotanist(event.target.checked);
+                                    }}
+                                />
+                            </div>
+                        </React.Fragment>
+                        )}
                         <MultiplierGroup
                             title="Output multipliers"
                             multiplierData={skillData.outputMultipliers}

--- a/src/util/calculator-util.js
+++ b/src/util/calculator-util.js
@@ -7,7 +7,7 @@ export function getFormatters() {
         amountFormatter: amountFormatter,
         outputListFormatter: outputListFormatter,
         inputListFormatter: inputListFormatter,
-        expFormatter: expFormatter,
+        expFormatter: expFormatter
     }
 }
 
@@ -74,7 +74,12 @@ function inputListFormatter(cell, row, rowIndex, props) {
         row.expMultipliers,
         props.totalLevel
     );
-    return itemListFormatter(cell, countMultiplier, actionsRemaining);
+    if (props.hasDoubleCast) {
+        return itemListDoubleCastFormatter(cell, countMultiplier, actionsRemaining);
+    } else {
+        return itemListFormatter(cell, countMultiplier, actionsRemaining);
+	}
+
 }
 
 function itemListFormatter(cell, countMultiplier, actionsRemaining) {
@@ -84,6 +89,21 @@ function itemListFormatter(cell, countMultiplier, actionsRemaining) {
                 if (item.amount) {
                     var amount = actionsRemaining * item.amount * item.chance * countMultiplier;
                     amount = +amount.toFixed(2);
+                    return <li key={item.name}>{amount + ' ' + item.name}</li>;
+                }
+                return <li key={item.name}>{item.name}</li>;
+            })}
+        </ul>
+    );
+}
+
+function itemListDoubleCastFormatter(cell, countMultiplier, actionsRemaining) {
+    return (
+        <ul>
+            {cell.map(item => {
+                if (item.amount) {
+                    var amount = actionsRemaining * item.amount * (item.chance * 0.1) * countMultiplier;
+                    amount = Math.ceil(amount)
                     return <li key={item.name}>{amount + ' ' + item.name}</li>;
                 }
                 return <li key={item.name}>{item.name}</li>;

--- a/src/util/calculator-util.js
+++ b/src/util/calculator-util.js
@@ -102,8 +102,13 @@ function itemListDoubleCastFormatter(cell, countMultiplier, actionsRemaining) {
         <ul>
             {cell.map(item => {
                 if (item.amount) {
-                    var amount = actionsRemaining * item.amount * (item.chance * 0.1) * countMultiplier;
-                    amount = Math.ceil(amount)
+                    if (item.name.includes('rune')){
+                        var amount = actionsRemaining * item.amount * (item.chance * 0.1) * countMultiplier;
+                        amount = Math.ceil(amount)
+                    } else {
+                        var amount = actionsRemaining * item.amount * item.chance * countMultiplier;
+                        amount = +amount.toFixed(2);
+                    }
                     return <li key={item.name}>{amount + ' ' + item.name}</li>;
                 }
                 return <li key={item.name}>{item.name}</li>;

--- a/src/util/calculator-util.js
+++ b/src/util/calculator-util.js
@@ -60,7 +60,11 @@ function outputListFormatter(cell, row, rowIndex, props) {
         row.expMultipliers,
         props.totalLevel
     );
-    return itemListFormatter(cell, countMultiplier, actionsRemaining);
+    if (props.hasBotanist) {
+        return itemListBotanistFormatter(cell, countMultiplier, actionsRemaining);
+    } else {
+        return itemListFormatter(cell, countMultiplier, actionsRemaining);
+    }
 }
 
 function inputListFormatter(cell, row, rowIndex, props) {
@@ -102,11 +106,12 @@ function itemListDoubleCastFormatter(cell, countMultiplier, actionsRemaining) {
         <ul>
             {cell.map(item => {
                 if (item.amount) {
+                    var amount
                     if (item.name.includes('rune')){
-                        var amount = actionsRemaining * item.amount * (item.chance * 0.1) * countMultiplier;
+                        amount = actionsRemaining * item.amount * (item.chance * 0.1) * countMultiplier;
                         amount = Math.ceil(amount)
                     } else {
-                        var amount = actionsRemaining * item.amount * item.chance * countMultiplier;
+                        amount = actionsRemaining * item.amount * item.chance * countMultiplier;
                         amount = +amount.toFixed(2);
                     }
                     return <li key={item.name}>{amount + ' ' + item.name}</li>;
@@ -116,6 +121,23 @@ function itemListDoubleCastFormatter(cell, countMultiplier, actionsRemaining) {
         </ul>
     );
 }
+
+function itemListBotanistFormatter(cell, countMultiplier, actionsRemaining) {
+    return (
+        <ul>
+            {cell.map(item => {
+                if (item.amount) {
+                    var amount = actionsRemaining * item.amount * item.chance * countMultiplier;
+                    amount = +amount.toFixed(2);
+                    amount = amount*2;
+                    return <li key={item.name}>{amount + ' ' + item.name}</li>;
+                }
+                return <li key={item.name}>{item.name}</li>;
+            })}
+        </ul>
+    );
+}
+
 
 function calcExpPerAction(baseExp, baseMultiplierStr, expMultiplier, validMultipliers, totalLevel) {
     const baseMultiplier = parseInt(baseMultiplierStr);


### PR DESCRIPTION
Adds the following checkbox under the Magic Calculator:
![image](https://user-images.githubusercontent.com/425207/98383639-0a299500-204d-11eb-88c0-3a7c5707b4ca.png)
Will be automatically checked when the Relic is found in the Character Tracker.

Changes the Inputs to the following:
![image](https://user-images.githubusercontent.com/425207/98383676-1a417480-204d-11eb-8cc1-c0bd0b527357.png)
Disabling the checkbox returns it to the default input column

Does a 0.1 times on the input value (to simulate the 90% chance of runes being saved while casting)