### PR TITLE
Move logic for task importing into web app

### DIFF
--- a/src/util/runelite-util.js
+++ b/src/util/runelite-util.js
@@ -93,8 +93,6 @@ function runeliteJsonToStorageFormat(json) {
     storageFormat[LOCALSTORAGE_KEYS.TASKS] = JSON.stringify(extractRuneliteTasks(parsedJson));
     storageFormat[LOCALSTORAGE_KEYS.UNLOCKED_REGIONS] = JSON.stringify(extractRuneliteAreas(parsedJson));
     storageFormat[LOCALSTORAGE_KEYS.UNLOCKED_RELICS] = JSON.stringify(extractRuneliteRelics(parsedJson));
-
-    console.log(storageFormat);
     
     return storageFormat;
 }

--- a/src/util/runelite-util.js
+++ b/src/util/runelite-util.js
@@ -1,14 +1,38 @@
-import { getFromLocalStorage, updateLocalStorage } from "./browser-util";
+import { getFromLocalStorage, LOCALSTORAGE_KEYS, updateLocalStorage } from "./browser-util";
+import taskData from '../resources/taskData.json';
+import relicData from '../resources/relicData.json';
+
+const TASKS_BY_NAME = getTaskLookupByName();
+const RELICS_BY_NAME = getRelicLookupByName();
+const RELIC_ENUM_TO_NAME = {
+    ENDLESS_HARVEST: "Endless Harvest",
+    PRODUCTION_MASTER: "Production Master",
+    SKILLING_PRODIGY: "Skilling Prodigy",
+    FAIRYS_FLIGHT: "Fairy's Flight",
+    ETERNAL_JEWELLER: "Eternal Jeweller",
+    LAST_RECALL: "Last Recall",
+    QUICK_SHOT: "Quick Shot",
+    FLUID_STRIKES: "Fluid Strikes",
+    DOUBLE_CAST: "Double Cast",
+    TREASURE_SEEKER: "Treasure Seeker",
+    UNNATURAL_SELECTION: "Unnatural Selection",
+    BOTANIST: "Botanist",
+    INFERNAL_GATHERING: "Infernal Gathering",
+    EQUILIBRIUM: "Equilibrium",
+    DRAINING_STRIKES: "Draining Strikes",
+    EXPLODING_ATTACKS: "Exploding Attacks",
+    WEAPON_SPECIALIST: "Weapon Specialist",
+}
 
 export async function updateLocalStorageFromRuneliteJson(json) {
     try {
-        const runeliteImport = JSON.parse(json);
+        const runeliteImport = runeliteJsonToStorageFormat(json);
         for (let [key, value] of Object.entries(runeliteImport)) {
             if (key === "tasks") {
                 const tasksImport = JSON.parse(value);
                 let tasks = getFromLocalStorage("tasks", {version:0, tasks:[], hidden:[], todoList:[]});
-                tasks.tasks = tasksImport.tasks;
-                tasks.version = tasksImport.version;
+                tasks.tasks = tasksImport;
+                tasks.version = 3;
                 updateLocalStorage("tasks", tasks);
 
             } else {
@@ -26,5 +50,87 @@ export async function updateLocalStorageFromRuneliteJson(json) {
             message: "Error parsing the import data: " + e
         };
     }
+}
+
+function getTaskLookupByName() {
+    let lookup = {};
+    taskData.tasks.forEach(task => lookup[sanitizeTaskName(task.name)] = task);
+    return lookup;
+}
+
+function getRelicLookupByName() {
+    let lookup = {}
+    relicData.forEach((slot, slotIndex) => {
+        slot.relics.forEach((relic, relicIndex) => {
+            lookup[relic.name] = {};
+            lookup[relic.name][slotIndex] = {
+                passive: true,
+                relic: relicIndex
+            };
+        })
+    });
+    return lookup;
+}
+
+function isValidRuneliteJson(json)
+{
+    return (
+        json.hasOwnProperty("relics") &&
+        json.hasOwnProperty("areas") &&
+        json.hasOwnProperty("tasks"));
+}
+
+function runeliteJsonToStorageFormat(json) {
+    const parsedJson = JSON.parse(json);
+    if(!isValidRuneliteJson(parsedJson))
+    {
+        throw new Error("The Runelite import data is invalid.");
+    }
+
+    let storageFormat = {};
+    storageFormat[LOCALSTORAGE_KEYS.TASKS] = JSON.stringify(extractRuneliteTasks(parsedJson));
+    storageFormat[LOCALSTORAGE_KEYS.UNLOCKED_REGIONS] = JSON.stringify(extractRuneliteAreas(parsedJson));
+    storageFormat[LOCALSTORAGE_KEYS.UNLOCKED_RELICS] = JSON.stringify(extractRuneliteRelics(parsedJson));
+
+    console.log(storageFormat);
     
+    return storageFormat;
+}
+
+function extractRuneliteTasks(runeliteJson) {
+    let tasks = runeliteJson.tasks
+        .filter(task => task.completed)
+        .map(task => {
+            const match = TASKS_BY_NAME[sanitizeTaskName(task.name)];
+            if (!match) throw new Error("Task match not found for " + task.name);
+            return match.id;
+        });
+
+    return tasks;
+}
+
+function extractRuneliteAreas(runeliteJson) {
+    return runeliteJson.areas.map(area => toPascalCase(area));
+}
+
+function extractRuneliteRelics(runeliteJson) {
+    return runeliteJson.relics.map(relic => {
+        const relicName = RELIC_ENUM_TO_NAME[relic];
+        if (!relicName) throw new Error("Relic name not found for enum: " + relic);
+        const match = RELICS_BY_NAME[relicName];
+        if (!match) throw new Error("Relic match not found for " + relicName);
+        return match;
+    });
+}
+
+function toPascalCase(areaName) {
+    if (typeof areaName !== "string") return "";
+    areaName = areaName.toLowerCase();
+    return areaName.charAt(0).toUpperCase() + areaName.slice(1);
+}
+
+function sanitizeTaskName(taskName) {
+    taskName = taskName.replaceAll(",", "");
+    taskName = taskName.toLowerCase();
+    return taskName;
 }

--- a/src/util/runelite-util.js
+++ b/src/util/runelite-util.js
@@ -62,12 +62,14 @@ function getRelicLookupByName() {
     let lookup = {}
     relicData.forEach((slot, slotIndex) => {
         slot.relics.forEach((relic, relicIndex) => {
-            lookup[relic.name] = {};
-            lookup[relic.name][slotIndex] = {
-                passive: true,
-                relic: relicIndex
+            lookup[relic.name] = {
+                slot: slotIndex,
+                relic: {
+                    passive: true,
+                    relic: relicIndex
+                }
             };
-        })
+        });
     });
     return lookup;
 }
@@ -114,13 +116,16 @@ function extractRuneliteAreas(runeliteJson) {
 }
 
 function extractRuneliteRelics(runeliteJson) {
-    return runeliteJson.relics.map(relic => {
+    const relics = {};
+    runeliteJson.relics.forEach(relic => {
         const relicName = RELIC_ENUM_TO_NAME[relic];
         if (!relicName) throw new Error("Relic name not found for enum: " + relic);
-        const match = RELICS_BY_NAME[relicName];
-        if (!match) throw new Error("Relic match not found for " + relicName);
-        return match;
+        const matched = RELICS_BY_NAME[relicName];
+        if (!matched) throw new Error("Relic match not found for " + relicName);
+        relics[matched.slot] = matched.relic;
     });
+
+    return relics;
 }
 
 function toPascalCase(areaName) {


### PR DESCRIPTION
### Changes

1. The Runelite plugin will no longer attempt to transform tasks from in-game to the task json format for the web app
2. Instead, the Runelite plugin now exports raw task information, which is then transformed in the webapp during import.

### Notes
**This change DOES NOT revert the Runelite import block.**
Thus, the PR can be accepted prior to the Runelite plugin being accepted.