### PR TITLE
Hide the inputs/outputs column from skill calculators if there's no data

### DIFF
--- a/src/pages/SkillCalculator.js
+++ b/src/pages/SkillCalculator.js
@@ -155,6 +155,8 @@ export default function SkillCalculator() {
         }
     ];
 
+    const data = applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas);
+
     return (
         <div className="content-wrapper">
             <h1 className="mt-2 light-text text-center">{skillData.name}</h1>
@@ -357,8 +359,8 @@ export default function SkillCalculator() {
                         <BootstrapTable
                             bootstrap4
                             keyField='id'
-                            data={applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas)}
-                            columns={columns}
+                            data={data}
+                            columns={columnsWithData(columns, data)}
                             bordered={false}
                             classes="light-text"
                             filter={filterFactory()}
@@ -386,4 +388,21 @@ function applyFilters(actions, currentLevel, useLevelFilter, isSkillingProdigy, 
         });
     }
     return filteredActions;
+}
+
+function columnsWithData(columns, data) {
+    const hasNoInputs = !data.some((datum) => datum.inputs.length > 0);
+    const hasNoOutputs = !data.some((datum) => datum.outputs.length > 0);
+
+    if (hasNoInputs) {
+        const inputsIndex = columns.findIndex((column) => column.dataField === "inputs");
+        columns.splice(inputsIndex, 1);
+    }
+
+    if (hasNoOutputs) {
+        const outputsIndex = columns.findIndex((column) => column.dataField === "outputs");
+        columns.splice(outputsIndex, 1);
+    }
+
+    return columns;
 }

--- a/src/pages/SkillCalculator.js
+++ b/src/pages/SkillCalculator.js
@@ -60,6 +60,9 @@ export default function SkillCalculator() {
     const isFarming = skillData.name === "Farming" ? true : false;
 
     const { nameFormatter, levelFormatter, amountFormatter, outputListFormatter, inputListFormatter, expFormatter } = getFormatters();
+
+    const data = applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas);
+
     const columns = [
         {
             "dataField": "id",
@@ -135,7 +138,8 @@ export default function SkillCalculator() {
                 "totalLevel": totalLevel,
                 "countMultiplier": inputMultiplier,
                 "hasDoubleCast": isMagic ? hasDoubleCast : false,
-            }
+            },
+            "hidden": !data.some((datum) => datum.inputs.length > 0)
         },
         {
             "dataField": "outputs",
@@ -151,11 +155,10 @@ export default function SkillCalculator() {
                 "totalLevel": totalLevel,
                 "countMultiplier": outputMultiplier,
                 "hasBotanist": isFarming ? hasBotanist : false,
-            }
+            },
+            "hidden": !data.some((datum) => datum.outputs.length > 0)
         }
     ];
-
-    const data = applyFilters(skillData.actions, currentLevel.level, useLevelFilter, isSkillingProdigy, useAreaFilter, includedAreas);
 
     return (
         <div className="content-wrapper">
@@ -360,7 +363,7 @@ export default function SkillCalculator() {
                             bootstrap4
                             keyField='id'
                             data={data}
-                            columns={columnsWithData(columns, data)}
+                            columns={columns}
                             bordered={false}
                             classes="light-text"
                             filter={filterFactory()}
@@ -388,21 +391,4 @@ function applyFilters(actions, currentLevel, useLevelFilter, isSkillingProdigy, 
         });
     }
     return filteredActions;
-}
-
-function columnsWithData(columns, data) {
-    const hasNoInputs = !data.some((datum) => datum.inputs.length > 0);
-    const hasNoOutputs = !data.some((datum) => datum.outputs.length > 0);
-
-    if (hasNoInputs) {
-        const inputsIndex = columns.findIndex((column) => column.dataField === "inputs");
-        columns.splice(inputsIndex, 1);
-    }
-
-    if (hasNoOutputs) {
-        const outputsIndex = columns.findIndex((column) => column.dataField === "outputs");
-        columns.splice(outputsIndex, 1);
-    }
-
-    return columns;
 }


### PR DESCRIPTION
I saw in the Discord that you have a task to hide the input and outputs column if those columns have no data. This PR does that, but I'm not 100% sure if it's exactly what you expect.

The one thing I question is the case where filtering would remove outputs. For example, if I'm using the magic calculator and I'm level 1, then I filter the items that I don't have the level for, this PR will remove the outputs column.

![image](https://user-images.githubusercontent.com/9084712/99490059-e6ecc880-291d-11eb-95a5-2a6cfa1e33f4.png)

If I then bump the level up to 4, where I can enchant Opal bolts, I would get the outputs column back.
![image](https://user-images.githubusercontent.com/9084712/99490094-008e1000-291e-11eb-87f8-e3f10a500f12.png)


Outside of that, the columns seem to work as expected. I posted a few more images below for examples:

Agility doesn't have any inputs so the column is hidden.
![image](https://user-images.githubusercontent.com/9084712/99489842-75ad1580-291d-11eb-8a36-df7e6ae502b9.png)

Similarly, firemaking doesn't have any outputs so the column is hidden.
![image](https://user-images.githubusercontent.com/9084712/99490187-3632f900-291e-11eb-91bf-3f2ce534ad12.png)


The skills that have both inputs and outputs should be unaffected.
![image](https://user-images.githubusercontent.com/9084712/99489904-a1300000-291d-11eb-8341-df5bb32d3476.png)

I couldn't find an example of a calculator that has neither inputs nor outputs (probably because there's always at least one).

(I'm Welfare PvM#6187 on Discord if you have questions/comments)